### PR TITLE
[Refactor] BobmooText 텍스트 스타일 적용 방식 전환

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS/Extensions/Font+.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Extensions/Font+.swift
@@ -137,23 +137,19 @@ private struct BobmooTypographyModifier: ViewModifier {
     }
 }
 
-struct BobmooText<Content: View>: View {
+struct BobmooText: View {
+    private let text: String
     private let style: BobmooFontName
     private let multiline: Bool
-    private let content: Content
 
-    init(
-        _ style: BobmooFontName,
-        multiline: Bool = false,
-        @ViewBuilder content: () -> Content
-    ) {
+    init(_ text: String, style: BobmooFontName, multiline: Bool = false) {
+        self.text = text
         self.style = style
         self.multiline = multiline
-        self.content = content()
     }
 
     var body: some View {
-        content
+        Text(text)
             .bobmooTypography(style, multiline: multiline)
     }
 }

--- a/Bobmoo_iOS/Bobmoo_iOS/HomeView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/HomeView.swift
@@ -9,14 +9,12 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        BobmooText(.body_m_11) {
-            Text("운영종료")
-                .foregroundStyle(.Bobmoo_White)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 1.5)
-                .background(.Bobmoo_Red)
-                .clipShape(Capsule())
-        }
+        BobmooText("운영종료", style: .body_m_11)
+            .foregroundStyle(.Bobmoo_White)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 1.5)
+            .background(.Bobmoo_Red)
+            .clipShape(Capsule())
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #5
- Linear: https://linear.app/bobmoo/issue/BOB-13/refactor-bobmootext-뷰-빌더-텍스트-스타일-전환

## 📄 작업 내용
- `BobmooText("...", style: .fontToken)` 시그니처를 도입해 텍스트 스타일 적용 진입점을 단일화했습니다.
- 텍스트 스타일 적용 경로를 `font+tracking`에서 `font+tracking+lineHeight`로 확장했습니다.
- `body_m_11` 토큰에 lineHeight(21)를 반영하고, 공통 `bobmooTypography` 모디파이어로 단일/멀티라인 처리 기준을 통일했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## ✅ Testing
- 테스트 목적과 상황: BobmooText 시그니처 전환 및 lineHeight 적용 후 컴파일/진단 확인
- 시나리오 진행에 필요한 값: `BobmooText("운영종료", style: .body_m_11)` 샘플 텍스트
- 시나리오 진행에 필요한 조건: SourceKit diagnostics, xcodebuild build
- 시나리오 완료 시 보장하는 결과: 변경 파일(`Extensions/Font+.swift`, `HomeView.swift`) 진단 0, Debug(iOS Simulator) 빌드 성공

## 💻 주요 코드 설명
`Extensions/Font+.swift`
- `BobmooText`를 문자열+스타일 기반 API로 제공해 호출부를 간결화했습니다.
- `bobmooTypography(_:multiline:)`로 lineHeight 기반 레이아웃을 통합 적용합니다.
```swift
BobmooText("운영종료", style: .body_m_11)
```

## 📚 참고자료
- 없음

## 👀 기타 더 이야기해볼 점
- 버튼 컴포넌트 관련 변경은 본 PR 범위에서 제외했습니다.