### PR TITLE
[Feature] BobmooLabel 상태 라벨 컴포넌트 추가

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS/Components/BobmooLabel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Components/BobmooLabel.swift
@@ -1,0 +1,84 @@
+//
+//  BobmooButton.swift
+//  Bobmoo_iOS
+//
+//  Created by 송성용 on 2/14/26.
+//
+
+import SwiftUI
+
+struct OperationPeriod {
+    let startAt: Date
+    let endAt: Date
+}
+
+enum OperationStatus {
+    case before
+    case active
+    case ended
+}
+
+enum OperationStatusResolver {
+    static func resolve(now: Date, period: OperationPeriod) -> OperationStatus {
+        if now < period.startAt {
+            return .before
+        }
+
+        if now <= period.endAt {
+            return .active
+        }
+
+        return .ended
+    }
+}
+
+struct BobmooLabel: View {
+    private let status: OperationStatus
+
+    init(status: OperationStatus) {
+        self.status = status
+    }
+
+    // 시간계산을 염두한 설계
+    init(period: OperationPeriod, now: Date = Date()) {
+        let resolved = OperationStatusResolver.resolve(now: now, period: period)
+        self.init(status: resolved)
+    }
+
+    var body: some View {
+        BobmooText(title, style: .body_m_11)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 1.5)
+            .background(backgroundColor)
+            .clipShape(Capsule())
+            .foregroundStyle(.white)
+    }
+
+    private var title: String {
+        switch status {
+        case .before:
+            return "운영전"
+        case .active:
+            return "운영중"
+        case .ended:
+            return "운영종료"
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch status {
+        case .before:
+            return .gray
+        case .active:
+            return .blue
+        case .ended:
+            return .red
+        }
+    }
+}
+
+#Preview {
+    BobmooLabel(status: .active)
+    BobmooLabel(status: .before)
+    BobmooLabel(status: .ended)
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #4
- Linear: https://linear.app/bobmoo/issue/BOB-18/feature-bobmoolabel-상태-라벨-컴포넌트-추가

## 📄 작업 내용
- `BobmooLabel`을 상태 기반 컴포넌트로 정리했습니다.
- `OperationStatus` enum과 `OperationStatusResolver`를 추가해 표시 라벨을 단일 진입점에서 관리하도록 구성했습니다.
- `period/now` 편의 init을 제공해 이후 시간 기반 상태 계산으로 바로 확장할 수 있게 했습니다.
- 줄바꿈/스위치 케이스 포맷을 프로젝트 스타일에 맞게 정리했습니다.

## 🧭 구현 의도 / 결정 이유
- 구현 의도:
  - 상태별 라벨 UI를 중복 없이 재사용 가능한 단일 컴포넌트로 관리하려고 했습니다.
  - 이후 운영 상태를 시간으로 계산하는 요구를 바로 수용할 수 있게 `status` 직접 주입 방식과 `period/now` 편의 init을 함께 제공했습니다.
- 결정 이유:
  - View 내부 렌더링 로직은 단일 `status` 경로로 통일하면 유지보수 시 분기 누락 위험이 줄어듭니다.
  - 시간 계산 로직을 `OperationStatusResolver`로 분리해 테스트/확장 포인트를 명확히 했습니다.
  - 이번 변경 범위를 라벨 컴포넌트 단위로 제한해 기존 화면 영향도를 최소화했습니다.
- 고려한 대안(선택):
  - `BobmooLabel` 내부에서 바로 시간 비교만 하는 방식도 가능했지만, 계산 로직과 뷰를 분리하는 현재 구조가 확장/검증에 유리해 선택했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | N/A | N/A |

## ✅ Testing
- 테스트 목적과 상황
  - 상태별 텍스트/배경색 매핑이 올바르게 표시되는지 확인

- 시나리오 진행에 필요한 값
  - `status: .before / .active / .ended`
  - `period(startAt:endAt:)`, `now`

- 시나리오 진행에 필요한 조건
  - Preview 및 SwiftUI 렌더링 가능 환경

- 시나리오 완료 시 보장하는 결과
  - 운영전/운영중/운영종료 라벨이 상태에 따라 일관되게 렌더링됨

## 💻 주요 코드 설명
`Bobmoo_iOS/Bobmoo_iOS/Components/BobmooLabel.swift`
- `init(status:)`로 직접 상태를 지정하거나, `init(period:now:)`로 시간 기반 상태를 내부에서 resolve해 동일 렌더 경로를 사용합니다.
```swift
BobmooLabel(status: .active)

let period = OperationPeriod(startAt: start, endAt: end)
BobmooLabel(period: period, now: Date())
```

## 📚 참고자료
- 없음

## 👀 기타 더 이야기해볼 점
- 이후 색상 토큰(`.bobmoo*`) 사용으로 매핑 정리하면 디자인 시스템 일관성이 더 좋아집니다.