### PR TITLE
[Chore] 기존 앱 Bundle ID로 업데이트 배포 전환

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.pbxproj
+++ b/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.pbxproj
@@ -268,7 +268,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "soseoyo.Bobmoo-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -302,7 +302,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "soseoyo.Bobmoo-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #22
- Linear: https://linear.app/bobmoo/issue/BOB-42/chore-기존-앱-bundle-id로-업데이트-배포-전환

## 📄 작업 내용
- 기존 앱 업데이트 배포를 위해 `PRODUCT_BUNDLE_IDENTIFIER`를 기존 식별자로 통일했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## ✅ Testing
- 테스트 목적과 상황: 빌드 설정의 번들 식별자 해석값이 의도한 값으로 고정되는지 확인
- 시나리오 진행에 필요한 값: `PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS`
- 시나리오 진행에 필요한 조건: Debug/Release 설정 모두 동일 반영
- 시나리오 완료 시 보장하는 결과: `xcodebuild -showBuildSettings`에서 동일 번들 ID가 출력됨

## 💻 주요 코드 설명
`Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.pbxproj`
- Target Build Settings의 `PRODUCT_BUNDLE_IDENTIFIER`를 Debug/Release 모두 동일 값으로 맞췄습니다.
```text
PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS;
```

## 📚 참고자료
- https://developer.apple.com/documentation/xcode/configuring-your-app-to-use-app-services

## 👀 기타 더 이야기해볼 점
- App Store Connect의 기존 App ID/Capability와 값이 완전히 일치하는지 업로드 전 최종 확인이 필요합니다.