### PR TITLE
Refactor/#38 ViewModel errorMessage를 catch 블록에 연결하고 에러 UI 표시

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS/Home/HomeView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Home/HomeView.swift
@@ -56,7 +56,47 @@ struct DayMenuPageView: View {
         let cafeterias = viewModel.menu(for: date)?.cafeterias ?? []
 
         Group {
-            if viewModel.isEmptyMenu(for: date) {
+            if let errorMessage = viewModel.errorMessage {
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        Image(.bobmooLogo)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 59)
+                            .padding(.top, 127)
+
+                        BobmooText("데이터를 불러올 수 없어요", style: .body_sb_18)
+                            .padding(.top, 24)
+
+                        BobmooText(errorMessage, style: .body_sb_15)
+                            .foregroundStyle(.bobmooGray3)
+                            .padding(.top, 21)
+
+                        Image(.iconArrow)
+                            .padding(.top, 118)
+
+                        BobmooText("아래로 당겨 새로고침", style: .body_sb_11)
+                            .foregroundStyle(.bobmooGray3)
+                            .padding(.top, 7)
+                            .padding(.bottom, 128)
+
+                        Spacer()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        Rectangle()
+                            .cornerRadius(15)
+                            .foregroundStyle(.bobmooWhite)
+                    )
+                    .padding(.horizontal, 28)
+                    .padding(.top, 30)
+                }
+                .scrollBounceBehavior(.always)
+                .refreshable {
+                    viewModel.errorMessage = nil
+                    await viewModel.reloadDate(date)
+                }
+            } else if viewModel.isEmptyMenu(for: date) {
                 ScrollView(showsIndicators: false) {
                     EmptyView()
                 }

--- a/Bobmoo_iOS/Bobmoo_iOS/Home/HomeViewModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Home/HomeViewModel.swift
@@ -96,6 +96,7 @@ final class HomeViewModel {
     // MARK: - Loading
 
     func preload() async {
+        errorMessage = nil
         let cal = Calendar.current
         let today = cal.startOfDay(for: Date())
         let yesterday = cal.date(byAdding: .day, value: -1, to: today)!
@@ -119,6 +120,10 @@ final class HomeViewModel {
                 menuCache[key] = result
             }
         } catch {
+            let school = AppConfig.selectedSchool ?? ""
+            if !school.isEmpty {
+                errorMessage = error.localizedDescription
+            }
             print("[HomeViewModel] loadIfNeeded(\(key)) failed: \(error)")
         }
     }
@@ -134,6 +139,7 @@ final class HomeViewModel {
                 menuCache[key] = result
             }
         } catch {
+            errorMessage = error.localizedDescription
             print("[HomeViewModel] reloadDate(\(key)) failed: \(error)")
         }
     }

--- a/Bobmoo_iOS/Bobmoo_iOS/Search/SearchView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Search/SearchView.swift
@@ -37,6 +37,14 @@ struct SearchView: View {
         .task {
             await viewModel.fetchSchools()
         }
+        .alert("오류", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("확인") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
     }
 }
 

--- a/Bobmoo_iOS/Bobmoo_iOS/Search/SearchViewModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Search/SearchViewModel.swift
@@ -34,6 +34,7 @@ final class SearchViewModel {
                 schools = response.data
             }
         } catch {
+            errorMessage = error.localizedDescription
             print("[SearchViewModel] fetchSchools failed: \(error)")
         }
     }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #38
- Linear: https://linear.app/bobmoo/issue/BOB-75
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/38
- [x] Linear/GitHub 이슈 상호 링크 확인

## 📄 작업 내용
- HomeViewModel의 loadIfNeeded, reloadDate catch 블록에 errorMessage 할당 추가
- SearchViewModel의 fetchSchools catch 블록에 errorMessage 할당 추가
- HomeView DayMenuPageView에 에러 상태 UI 추가 (기존 EmptyView 스타일 차용, pull-to-refresh 지원)
- SearchView에 .alert 기반 에러 표시 추가
- preload() 시작 시 errorMessage = nil 초기화

## 🧭 구현 의도 / 결정 이유
- 구현 의도: 기존에 errorMessage 프로퍼티가 선언만 되고 실제 사용되지 않아 에러 발생 시 UI 피드백이 전혀 없었던 문제를 해결
- 결정 이유: .alert(SearchView)와 EmptyView 스타일 차용(HomeView)으로 최소한의 에러 표시를 구현. Toast/Banner/Retry 시스템은 스코프 밖으로 판단
- 고려한 대안: Toast 시스템 구축 -> 스코프 초과로 제외, Retry 버튼 -> pull-to-refresh로 대체

## ✅ Testing
- 테스트 목적: errorMessage가 catch 블록에서 올바르게 할당되고 UI에 표시되는지 확인
- 시나리오: 네트워크 에러 발생 시 HomeView에 에러 화면 표시, SearchView에 alert 표시
- 완료 조건: BUILD SUCCEEDED, errorMessage 할당 3곳(HomeVM 2 + SearchVM 1), print 유지, nil school 가드 존재

## 💻 주요 코드 설명
`HomeViewModel.swift`
- loadIfNeeded catch에서 school이 비어있지 않을 때만 errorMessage 할당 (첫 실행 시 학교 미선택 상태 에러 표시 방지)
- reloadDate catch에서는 항상 errorMessage 할당 (사용자가 명시적으로 새로고침한 경우)
- preload() 시작 시 errorMessage를 nil로 초기화

`HomeView.swift`
- DayMenuPageView에 errorMessage 분기 추가, 기존 EmptyView 디자인 패턴 차용
- .refreshable에서 errorMessage를 nil로 초기화 후 reloadDate 호출

`SearchView.swift`
- .alert modifier로 간단한 에러 표시 구현
