### PR TITLE
Feat/#46 앱 실행 시 업데이트 안내(Alert) 추가

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS/AppUpdate/AppUpdateModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/AppUpdate/AppUpdateModel.swift
@@ -1,0 +1,19 @@
+//
+//  AppUpdateModel.swift
+//  Bobmoo_iOS
+//
+//  Created by Antigravity on 2/25/26.
+//
+
+import Foundation
+
+struct iTunesLookupResponse: Codable {
+    let resultCount: Int
+    let results: [iTunesAppInfo]
+}
+
+struct iTunesAppInfo: Codable {
+    let trackId: Int
+    let version: String
+    let trackViewUrl: String
+}

--- a/Bobmoo_iOS/Bobmoo_iOS/AppUpdate/AppUpdateService.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/AppUpdate/AppUpdateService.swift
@@ -1,0 +1,95 @@
+//
+//  AppUpdateService.swift
+//  Bobmoo_iOS
+//
+//  Created by Antigravity on 2/25/26.
+//
+
+import Foundation
+import Alamofire
+
+// MARK: - Result
+
+enum AppUpdateResult {
+    case updateAvailable(storeURL: URL)
+    case upToDate
+    case failed
+}
+
+// MARK: - Protocol
+
+protocol AppUpdateService {
+    func checkForUpdate() async -> AppUpdateResult
+}
+
+// MARK: - API Implementation
+
+struct AppUpdateAPIService: AppUpdateService {
+
+    func checkForUpdate() async -> AppUpdateResult {
+        guard let bundleId = Bundle.main.bundleIdentifier else { return .failed }
+
+        let urlString = "https://itunes.apple.com/lookup?bundleId=\(bundleId)&country=kr"
+
+        // Use serializingData() to avoid Sendable constraint on iTunesLookupResponse,
+        // then decode manually — best-effort; any failure returns .failed.
+        let dataTask = Session.default.request(urlString, method: .get).validate(statusCode: 200..<300).serializingData()
+
+        do {
+            let data = try await dataTask.value
+            let lookupResponse = try JSONDecoder().decode(iTunesLookupResponse.self, from: data)
+
+            guard let appInfo = lookupResponse.results.first else { return .failed }
+
+            let currentVersion = (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0.0.0"
+
+            guard isNewerVersion(storeVersion: appInfo.version, currentVersion: currentVersion) else {
+                return .upToDate
+            }
+
+            let storeURL: URL
+            if let url = URL(string: "itms-apps://itunes.apple.com/app/id\(appInfo.trackId)") {
+                storeURL = url
+            } else if let url = URL(string: appInfo.trackViewUrl) {
+                storeURL = url
+            } else {
+                return .failed
+            }
+
+            return .updateAvailable(storeURL: storeURL)
+        } catch {
+            return .failed
+        }
+    }
+
+    /// Returns `true` when `storeVersion` is strictly greater than `currentVersion`.
+    /// Pads shorter version strings with zeros so "1.0" == "1.0.0" and "1.9.0" < "1.10.0".
+    private func isNewerVersion(storeVersion: String, currentVersion: String) -> Bool {
+        let store = storeVersion.split(separator: ".").compactMap { Int($0) }
+        let current = currentVersion.split(separator: ".").compactMap { Int($0) }
+        let length = max(store.count, current.count)
+
+        for i in 0..<length {
+            let s = i < store.count ? store[i] : 0
+            let c = i < current.count ? current[i] : 0
+            if s > c { return true }
+            if s < c { return false }
+        }
+        return false
+    }
+}
+
+// MARK: - Mock Implementation
+
+struct AppUpdateMockService: AppUpdateService {
+
+    let result: AppUpdateResult
+
+    init(result: AppUpdateResult = .upToDate) {
+        self.result = result
+    }
+
+    func checkForUpdate() async -> AppUpdateResult {
+        result
+    }
+}

--- a/Bobmoo_iOS/Bobmoo_iOS/Home/HomeViewModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Home/HomeViewModel.swift
@@ -109,7 +109,7 @@ final class HomeViewModel {
                 menuCache[key] = result
             }
         } catch {
-            let school = AppConfig.selectedSchool ?? ""
+            let school = settings.selectedSchool ?? ""
             if !school.isEmpty {
                 errorMessage = error.localizedDescription
             }

--- a/Bobmoo_iOS/Bobmoo_iOS/Splash/SplashView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Splash/SplashView.swift
@@ -6,13 +6,21 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct SplashView: View {
     let homeViewModel: HomeViewModel
+    let updateService: AppUpdateService
     let didTapStart: () -> Void
 
-    init(homeViewModel: HomeViewModel, didTapStart: @escaping () -> Void) {
+    @State private var updateURL: URL?
+    @State private var showUpdateAlert = false
+
+    init(homeViewModel: HomeViewModel,
+         updateService: AppUpdateService = AppUpdateAPIService(),
+         didTapStart: @escaping () -> Void) {
         self.homeViewModel = homeViewModel
+        self.updateService = updateService
         self.didTapStart = didTapStart
     }
 
@@ -46,13 +54,47 @@ struct SplashView: View {
                 .padding(.bottom, 21)
         }
         .task {
-            if !homeViewModel.isPreloaded {
-                await homeViewModel.preload()
+            async let preloadTask: () = preloadIfNeeded()
+            async let updateTask: () = checkForUpdate()
+            _ = await (preloadTask, updateTask)
+        }
+        .alert("업데이트 안내", isPresented: $showUpdateAlert) {
+            Button("업데이트") {
+                if let url = updateURL {
+                    UIApplication.shared.open(url)
+                }
             }
+            Button("나중에", role: .cancel) {}
+        } message: {
+            Text("새로운 버전이 출시되었습니다.\n더 나은 경험을 위해 업데이트해 주세요.")
+        }
+    }
+
+    private func preloadIfNeeded() async {
+        if !homeViewModel.isPreloaded {
+            await homeViewModel.preload()
+        }
+    }
+
+    @MainActor
+    private func checkForUpdate() async {
+        if case .updateAvailable(let storeURL) = await updateService.checkForUpdate() {
+            updateURL = storeURL
+            showUpdateAlert = true
         }
     }
 }
 
-#Preview {
+
+#Preview("기본") {
     SplashView(homeViewModel: HomeViewModel(service: HomeMockMenuService(), settings: AppSettings())) {}
+}
+
+#Preview("업데이트 있음") {
+    SplashView(
+        homeViewModel: HomeViewModel(service: HomeMockMenuService(), settings: AppSettings()),
+        updateService: AppUpdateMockService(result: .updateAvailable(
+            storeURL: URL(string: "itms-apps://itunes.apple.com/app/id123456789")!
+        ))
+    ) {}
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #46
- Linear: https://linear.app/bobmoo/issue/BOB-79/feature-앱-실행-시-업데이트-안내alert-추가
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/46
- [x] Linear/GitHub 이슈 상호 링크 확인

## 📄 작업 내용
- 앱 실행(Splash) 시 iTunes Lookup API로 App Store 최신 버전 조회
- 스토어 버전이 현재 버전보다 높으면 "업데이트 안내" Alert 표시
- "업데이트" 버튼 탭 시 App Store로 이동, "나중에" 버튼 탭 시 닫기
- 업데이트 체크 실패/빈 결과는 best-effort로 무시 (앱 사용 방해 없음)

## 🧭 구현 의도 / 결정 이유
- 구현 의도: 사용자가 구버전을 사용 중일 때 앱 진입 시점에 업데이트를 안내
- 결정 이유: 백엔드 변경 없이 iTunes Lookup으로 최신 버전 확인 가능; 스플래시에서 preload와 병렬 실행해 UX 영향 최소화
- 고려한 대안(선택): 최소버전 강제(백엔드/Remote Config) 방식은 범위 밖이라 제외

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## ✅ Testing
- `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "Bobmoo_iOS" -destination 'generic/platform=iOS Simulator' clean build`

## 💻 주요 코드 설명
`Bobmoo_iOS/Bobmoo_iOS/AppUpdate/AppUpdateService.swift`
- iTunes Lookup 호출 + Semantic version 비교(1.9.0 < 1.10.0, 1.0 == 1.0.0)

`Bobmoo_iOS/Bobmoo_iOS/Splash/SplashView.swift`
- preload와 업데이트 체크를 `.task`에서 병렬 실행하고, 결과에 따라 Alert 표시