### PR TITLE
Fix/#89 라이트 모드 강제

### DIFF
--- a/Bobmoo_iOS/Bobmoo-iOS-Info.plist
+++ b/Bobmoo_iOS/Bobmoo-iOS-Info.plist
@@ -27,5 +27,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Bobmoo_iOS/BobmooWidgetExtension/BobmooWidgetExtension.swift
+++ b/Bobmoo_iOS/BobmooWidgetExtension/BobmooWidgetExtension.swift
@@ -7,6 +7,7 @@ struct DietWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: DietProvider()) { entry in
             DietWidgetView(entry: entry)
+                .preferredColorScheme(.light)
                 .widgetURL({
                     let scheme = Bundle.main.object(forInfoDictionaryKey: "APP_URL_SCHEME") as? String ?? "bobmoo"
                     return URL(string: "\(scheme)://home")


### PR DESCRIPTION
## 연결된 이슈
- Linear: https://linear.app/bobmoo/issue/BOB-89/feature-라이트-모드-강제
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/55
- [x] Linear/GitHub 이슈 상호 링크를 확인했습니다.

## 작업 내용
- 앱 전체 인터페이스 스타일을 `UIUserInterfaceStyle = Light`로 고정했습니다.
- 위젯 루트 뷰에 `.preferredColorScheme(.light)`를 적용했습니다.

## 구현 의도 / 결정 이유
- 화면마다 개별적으로 색상 모드를 제어하지 않고 앱/위젯 루트에서 일괄 고정해 유지보수 비용과 누락 가능성을 줄였습니다.
- 위젯은 별도 extension 프로세스로 동작하므로 앱 설정과 분리해서 루트 설정을 추가했습니다.

## Testing
- [x] `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "BobmooWidgetExtension" -configuration Debug -sdk iphonesimulator build`
- [ ] `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "Bobmoo_iOS" -configuration Debug -sdk iphonesimulator build`  
  - fresh branch 기준 `Bobmoo_iOS/Bobmoo_iOS/Presentation/Setting/SettingView.swift:150` 에서 `ImageResource.bobmooLogo` 미존재로 실패했습니다. 이번 변경과는 무관한 기존 문제입니다.

## 주요 코드 설명
- `Bobmoo_iOS/Bobmoo-iOS-Info.plist`에서 앱 전체 라이트 모드를 강제했습니다.
- `Bobmoo_iOS/BobmooWidgetExtension/BobmooWidgetExtension.swift`에서 위젯 진입 루트에 라이트 모드 modifier를 적용했습니다.