### PR TITLE
Fix/#90 학교 선택 셀 전체 선택 상태 표시

### DIFF
--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchView.swift
@@ -76,24 +76,31 @@ struct SearchResultView: View {
                 .padding(.top, 18)
 
             ForEach(schools) { school in
+                let isSelected = selectedSchoolId == school.schoolId
+
                 Button {
                     onSelect(school)
                 } label: {
                     HStack(spacing: 0) {
                         BobmooText(school.displayName, style: .body_b_15)
+                            .foregroundStyle(isSelected ? .bobmooWhite : .bobmooBlack)
 
                         Spacer()
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .overlay(alignment: .trailing) {
-                        if selectedSchoolId == school.schoolId {
+                        if isSelected {
                             Image(.check)
+                                .foregroundStyle(.bobmooWhite)
                                 .padding(.trailing, 18)
                         }
                     }
                     .padding(.leading, 21)
                     .padding(.trailing, 18)
                     .padding(.top, 26)
+                    .padding(.bottom, 11)
+                    .background(isSelected ? .bobmooBlack : .bobmooWhite)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
                 .buttonStyle(.plain)
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #58
- Linear: https://linear.app/bobmoo/issue/BOB-90/bug-학교-선택-셀-전체-선택-표시-수정
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/58
- [x] Linear/GitHub 이슈 상호 링크 확인

## 📄 작업 내용
- 학교 검색 결과에서 선택된 학교가 텍스트 주변만 강조되는 대신, 셀 전체가 선택된 상태로 보이도록 수정했습니다.
- 선택된 행은 전체 배경, 텍스트, 체크 아이콘이 함께 바뀌어 한눈에 현재 선택값을 인식할 수 있도록 맞췄습니다.

## 🧭 구현 의도 / 결정 이유
- 구현 의도: 학교를 선택했을 때 사용자가 셀 전체를 선택 상태로 인지할 수 있도록 선택 표시 범위를 명확히 넓히기 위함입니다.
- 결정 이유: 기존 상태 로직은 `selectedSchoolId`로 충분해서, `SearchView`에서 선택된 행의 배경/텍스트/체크 아이콘 스타일만 조건부로 바꾸는 최소 수정이 가장 안전했습니다.
- 고려한 대안(선택): 탭 영역만 넓히는 방식은 시각적으로는 여전히 선택 범위가 좁아 보여 요구사항을 만족하지 못해 제외했습니다.

|    구현 내용    |   IPhone 16 pro   |   IPhone 13 mini   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## ✅ Testing
- 테스트 목적과 상황
  - 학교 검색 결과에서 선택된 학교가 셀 전체 선택 상태로 보이는지 확인
  - 전체 앱 빌드 가능 여부 확인

- 시나리오 진행에 필요한 값
  - 학교 검색 결과가 1개 이상 노출되는 검색어

- 시나리오 진행에 필요한 조건
  - `fix/#90-search-school-selection-highlight` 브랜치 체크아웃

- 시나리오 완료 시 보장하는 결과
  - `Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchView.swift`에서 선택된 학교 행이 전체 폭 배경, 흰 텍스트, 흰 체크 아이콘으로 표시됨
  - `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "Bobmoo_iOS" -destination 'generic/platform=iOS Simulator' build` 실행 시, 현재 변경과 무관하게 기존 `Bobmoo_iOS/Bobmoo_iOS/Presentation/Setting/SettingView.swift:150`의 `ImageResource.bobmooLogo` 오류로 전체 앱 빌드가 실패함을 확인

## 💻 주요 코드 설명
`SearchView`
- 각 학교 행에서 `selectedSchoolId`를 `isSelected`로 분리해 선택 여부를 명시적으로 사용했습니다.
- 선택된 행에만 전체 배경색, 텍스트 색, 체크 아이콘 색을 함께 적용해 셀 전체 선택 상태를 표현했습니다.
```swift
let isSelected = selectedSchoolId == school.schoolId

BobmooText(school.displayName, style: .body_b_15)
    .foregroundStyle(isSelected ? .bobmooWhite : .bobmooBlack)

.background(isSelected ? .bobmooBlack : .bobmooWhite)
.clipShape(RoundedRectangle(cornerRadius: 12))
```

## 👀 기타 더 이야기해볼 점
- Firebase/GA4 기준으로 `DAU/WAU/MAU`, 신규 사용자 수, 재방문율, 세션 수, 평균 사용 시간은 기본 리포트 성격으로 확인 가능합니다. Bobmoo에서는 이 기본 지표 위에 학교 선택/홈 조회/위젯 설정 같은 커스텀 퍼널 이벤트를 얹는 방식이 적절합니다.