### PR TITLE
Chore/#91 Firebase SDK 기본 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@
 .env
 config.env
 
+# Firebase local config
+Bobmoo_iOS/GoogleService-Info.plist
+
 # Sisyphus planning
 .sisyphus/

--- a/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.pbxproj
+++ b/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		C5828B6496A542AE95544934 /* Bobmoo_iOS/Network/APIConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DBF9905BF24ECC99C174CD /* Bobmoo_iOS/Network/APIConfig.swift */; };
 		CA47C2A02F488B33000D809C /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CA47C29F2F488B33000D809C /* Alamofire */; };
 		CA47C2B12F488B33000D809C /* BobmooWidgetExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = CA47C2A52F488B33000D809C /* BobmooWidgetExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CAA5B2632F63B60E00BE49E3 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = CAA5B2622F63B60E00BE49E3 /* FirebaseAnalytics */; };
+		CAA5B2652F63B65600BE49E3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CAA5B2642F63B65600BE49E3 /* GoogleService-Info.plist */; };
+		CAA5B2662F63B65600BE49E3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CAA5B2642F63B65600BE49E3 /* GoogleService-Info.plist */; };
 		D3A4953058454F03AE9F73AB /* Bobmoo_iOS/Resource/Fonts/Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 50C75F4D030F48788B2C98C6 /* Bobmoo_iOS/Resource/Fonts/Pretendard-Bold.otf */; };
 		DC345A57B1764B0C9C9174D0 /* Bobmoo_iOS/Resource/Extensions/OperationPeriod+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54C8B177962412CB960C50A /* Bobmoo_iOS/Resource/Extensions/OperationPeriod+Parse.swift */; };
 		E614BF936DFA478C8C7C00C3 /* Bobmoo_iOS/Resource/Extensions/UserDefaults+BobmooShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F071566EDF4EDC96BC62F1 /* Bobmoo_iOS/Resource/Extensions/UserDefaults+BobmooShared.swift */; };
@@ -64,6 +67,7 @@
 		BAE0912481DF4502AD55B1EE /* Bobmoo_iOS/Resource/Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Bobmoo_iOS/Resource/Assets.xcassets; sourceTree = "<group>"; };
 		CA47C2A52F488B33000D809C /* BobmooWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BobmooWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA8053762F3F3CF80013A6A0 /* Bobmoo_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bobmoo_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAA5B2642F63B65600BE49E3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CF4157B7E09D491DA5CF1A75 /* Bobmoo_iOS/Resource/Fonts/Pretendard-ExtraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Bobmoo_iOS/Resource/Fonts/Pretendard-ExtraLight.otf"; sourceTree = "<group>"; };
 		D9F071566EDF4EDC96BC62F1 /* Bobmoo_iOS/Resource/Extensions/UserDefaults+BobmooShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bobmoo_iOS/Resource/Extensions/UserDefaults+BobmooShared.swift"; sourceTree = "<group>"; };
 		E54C8B177962412CB960C50A /* Bobmoo_iOS/Resource/Extensions/OperationPeriod+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bobmoo_iOS/Resource/Extensions/OperationPeriod+Parse.swift"; sourceTree = "<group>"; };
@@ -94,6 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAA5B2632F63B60E00BE49E3 /* FirebaseAnalytics in Frameworks */,
 				CA47C2A02F488B33000D809C /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -126,6 +131,7 @@
 		CA80536D2F3F3CF70013A6A0 = {
 			isa = PBXGroup;
 			children = (
+				CAA5B2642F63B65600BE49E3 /* GoogleService-Info.plist */,
 				CA8053782F3F3CF80013A6A0 /* Bobmoo_iOS */,
 				CA47C2A92F488B33000D809C /* BobmooWidgetExtension */,
 				CA8053772F3F3CF80013A6A0 /* Products */,
@@ -185,6 +191,7 @@
 			name = Bobmoo_iOS;
 			packageProductDependencies = (
 				CA47C29F2F488B33000D809C /* Alamofire */,
+				CAA5B2622F63B60E00BE49E3 /* FirebaseAnalytics */,
 			);
 			productName = Bobmoo_iOS;
 			productReference = CA8053762F3F3CF80013A6A0 /* Bobmoo_iOS.app */;
@@ -219,6 +226,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				CA47C29E2F488B33000D809C /* XCRemoteSwiftPackageReference "Alamofire" */,
+				CAA5B2612F63B60E00BE49E3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CA8053772F3F3CF80013A6A0 /* Products */;
@@ -244,6 +252,7 @@
 				0ECE70815D6D4B169C3CD419 /* Bobmoo_iOS/Resource/Fonts/Pretendard-Light.otf in Resources */,
 				B97FFD4EA4D54EB1861AE87D /* Bobmoo_iOS/Resource/Fonts/Pretendard-Medium.otf in Resources */,
 				69E1B75386F14A4EBB3ED58E /* Bobmoo_iOS/Resource/Fonts/Pretendard-Regular.otf in Resources */,
+				CAA5B2652F63B65600BE49E3 /* GoogleService-Info.plist in Resources */,
 				284017BD3F3043179BD30222 /* Bobmoo_iOS/Resource/Fonts/Pretendard-SemiBold.otf in Resources */,
 				0771FDF131BD4A4C8F128251 /* Bobmoo_iOS/Resource/Fonts/Pretendard-Thin.otf in Resources */,
 			);
@@ -253,6 +262,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAA5B2662F63B65600BE49E3 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -499,7 +509,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -535,7 +545,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = soseoyo.BabmooiOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -589,6 +599,14 @@
 				minimumVersion = 5.11.1;
 			};
 		};
+		CAA5B2612F63B60E00BE49E3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.10.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -596,6 +614,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CA47C29E2F488B33000D809C /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		CAA5B2622F63B60E00BE49E3 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CAA5B2612F63B60E00BE49E3 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "11b78eba97192d19796cff581fdf69b3e65b441188b1448a1b67e5d7b825a354",
+  "originHash" : "4dcdb4ce6383a7788bcaabb062ff2a1f82a8f3c5c7259b80a888940fb1f0b0d1",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,114 @@
       "state" : {
         "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
         "version" : "5.11.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "85560b48b0ff099ad83fe53d67df3c67fbc2b7a6",
+        "version" : "12.10.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a5cd95c80e8efdd02155c6cea1cecf743bb683a5",
+        "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "68ba955e540dcff5e0805970ef4b1fd0150be100",
+        "version" : "12.10.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a883ddb9fd464216133a5ab441f1ae8995978573",
+        "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     }
   ],

--- a/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/xcshareddata/xcschemes/Bobmoo_iOS.xcscheme
+++ b/Bobmoo_iOS/Bobmoo_iOS.xcodeproj/xcshareddata/xcschemes/Bobmoo_iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "2.0">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Bobmoo_iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Bobmoo_iOSApp.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Bobmoo_iOSApp.swift
@@ -6,10 +6,19 @@
 //
 
 import SwiftUI
+import FirebaseCore
+import FirebaseAnalytics
 
 @main
 struct Bobmoo_iOSApp: App {
     @State private var settings = AppSettings()
+
+    init() {
+        FirebaseApp.configure()
+        Analytics.logEvent("debug_test", parameters: [
+            "source": "app_launch"
+        ])
+    }
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #60
- Linear: https://linear.app/bobmoo/issue/BOB-91/chore-firebase-sdk-기본-연동
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/60
- [x] Linear/GitHub 이슈 상호 링크 확인

## 📄 작업 내용
- Bobmoo iOS 앱 타깃에 Firebase Analytics 의존성을 연결했습니다.
- `GoogleService-Info.plist`를 앱 리소스로 포함하고 앱 시작 시 `FirebaseApp.configure()`가 실행되도록 구성했습니다.
- Firebase DebugView 확인을 위해 `Bobmoo_iOS` scheme에 `-FIRDebugEnabled` 실행 인자를 추가했습니다.

## 🧭 구현 의도 / 결정 이유
- 구현 의도: Bobmoo 앱에서 제품 분석 이벤트를 수집할 수 있는 Firebase 기반을 먼저 안정적으로 마련하기 위함입니다.
- 결정 이유: 초기 단계에서는 Firebase baseline만 정확히 붙이고, 앱 시작점에서 단일 configure 경로를 두는 것이 가장 단순하고 안전했습니다.
- 고려한 대안(선택): 설정 파일이 없을 때 configure를 건너뛰는 방어 코드도 검토했지만, 실제 `GoogleService-Info.plist`가 준비된 상태라 기본 경로를 유지했습니다.

## ✅ Testing
- 테스트 목적과 상황
  - Firebase SDK가 프로젝트에 정상 연결되고 앱 타깃이 빌드되는지 확인

- 시나리오 진행에 필요한 조건
  - `chore/#91-firebase-sdk-baseline-integration` 브랜치 체크아웃
  - `Bobmoo_iOS` scheme 사용

- 시나리오 완료 시 보장하는 결과
  - `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "Bobmoo_iOS" -destination 'generic/platform=iOS Simulator' -derivedDataPath "/Users/soseoyo/Documents/Programming/Bobmoo_iOS/.derivedData-firebase-pr" build` 실행 결과 `BUILD SUCCEEDED`
  - 앱 시작점에서 `FirebaseApp.configure()`가 호출되고, `GoogleService-Info.plist`가 앱 리소스로 포함됨

## 💻 주요 코드 설명
`Bobmoo_iOSApp`
- 앱 시작 시 Firebase를 초기화하도록 `FirebaseApp.configure()`를 추가했습니다.

`project.pbxproj`
- Firebase Analytics Swift Package 의존성과 `GoogleService-Info.plist` 리소스 포함을 프로젝트에 반영했습니다.

## 👀 기타 더 이야기해볼 점
- 이 PR은 Firebase baseline만 다루고 있고, 실제 상세 이벤트 설계/삽입은 별도 작업 단위인 `BOB-92`에서 진행 중입니다.