### PR TITLE
Feat/#92 상세 Firebase Analytics 이벤트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Xcode build artifacts
 **/build/
 .derivedData/
+.derivedData*/
 
 # Environment files
 .env

--- a/Bobmoo_iOS/Bobmoo_iOS/Analytics/BobmooAnalytics.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Analytics/BobmooAnalytics.swift
@@ -1,0 +1,181 @@
+import Foundation
+import FirebaseAnalytics
+
+enum BobmooScreen: String {
+    case splash
+    case onboarding
+    case search
+    case home
+    case setting
+}
+
+final class BobmooAnalytics {
+    static let shared = BobmooAnalytics()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private init() {}
+
+    func logScreenView(_ screen: BobmooScreen, entryPoint: String? = nil) {
+        var parameters: [String: Any] = [
+            AnalyticsParameterScreenName: screen.rawValue,
+            AnalyticsParameterScreenClass: "SwiftUI"
+        ]
+
+        if let entryPoint {
+            parameters["entry_point"] = entryPoint
+        }
+
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: parameters)
+    }
+
+    func logAppOpen(hasSelectedSchool: Bool) {
+        log("app_open", [
+            "has_selected_school": hasSelectedSchool
+        ])
+    }
+
+    func logOnboardingStarted(hasSelectedSchool: Bool) {
+        log("onboarding_started", [
+            "has_selected_school": hasSelectedSchool
+        ])
+    }
+
+    func logSearchResultsLoaded(count: Int) {
+        log("school_directory_loaded", [
+            "school_count": count
+        ])
+    }
+
+    func logSearch(queryLength: Int, resultCount: Int, isEmptyQuery: Bool) {
+        log("school_search", [
+            "query_length": queryLength,
+            "result_count": resultCount,
+            "is_empty_query": isEmptyQuery
+        ])
+    }
+
+    func logSchoolSelected(id: Int, name: String) {
+        log("school_selected", [
+            "school_id": id,
+            "school_name": name
+        ])
+    }
+
+    func logSchoolSelectionCompleted(selectedSchoolId: Int?, schoolName: String?) {
+        log("school_selection_completed", [
+            "has_selected_school": selectedSchoolId != nil,
+            "school_id": selectedSchoolId,
+            "school_name": schoolName
+        ])
+    }
+
+    func logHomeOpened(schoolName: String?, date: Date) {
+        log("home_opened", [
+            "school_name": schoolName,
+            "selected_date": Self.dateFormatter.string(from: date)
+        ])
+    }
+
+    func logDateSwiped(direction: String, fromDate: Date, toDate: Date) {
+        log("home_date_swiped", [
+            "direction": direction,
+            "from_date": Self.dateFormatter.string(from: fromDate),
+            "to_date": Self.dateFormatter.string(from: toDate)
+        ])
+    }
+
+    func logCalendarOpened(date: Date) {
+        log("calendar_opened", [
+            "selected_date": Self.dateFormatter.string(from: date)
+        ])
+    }
+
+    func logCalendarDateSelected(previousDate: Date, selectedDate: Date) {
+        log("calendar_date_selected", [
+            "previous_date": Self.dateFormatter.string(from: previousDate),
+            "selected_date": Self.dateFormatter.string(from: selectedDate)
+        ])
+    }
+
+    func logMenuViewed(date: Date, schoolName: String?, cafeteriaCount: Int, source: String) {
+        log("menu_day_viewed", [
+            "selected_date": Self.dateFormatter.string(from: date),
+            "school_name": schoolName,
+            "cafeteria_count": cafeteriaCount,
+            "source": source
+        ])
+    }
+
+    func logMenuReload(date: Date, source: String) {
+        log("menu_reloaded", [
+            "selected_date": Self.dateFormatter.string(from: date),
+            "source": source
+        ])
+    }
+
+    func logMenuLoadSucceeded(date: Date, schoolName: String?, cafeteriaCount: Int, source: String) {
+        log("menu_load_succeeded", [
+            "selected_date": Self.dateFormatter.string(from: date),
+            "school_name": schoolName,
+            "cafeteria_count": cafeteriaCount,
+            "source": source
+        ])
+    }
+
+    func logMenuLoadFailed(date: Date, schoolName: String?, source: String, errorMessage: String) {
+        log("menu_load_failed", [
+            "selected_date": Self.dateFormatter.string(from: date),
+            "school_name": schoolName,
+            "source": source,
+            "error_message": errorMessage
+        ])
+    }
+
+    func logSettingsOpened(source: String, schoolName: String?) {
+        log("settings_opened", [
+            "source": source,
+            "school_name": schoolName
+        ])
+    }
+
+    func logSchoolSettingTapped(currentSchoolName: String?) {
+        log("school_setting_tapped", [
+            "current_school_name": currentSchoolName
+        ])
+    }
+
+    func logWidgetCafeteriaChanged(previous: String, current: String) {
+        log("widget_cafeteria_changed", [
+            "previous_cafeteria": previous,
+            "selected_cafeteria": current
+        ])
+    }
+
+    func logUpdatePromptShown() {
+        log("update_prompt_shown")
+    }
+
+    func logUpdatePromptAction(_ action: String) {
+        log("update_prompt_action", [
+            "action": action
+        ])
+    }
+
+    func logDeepLinkOpened(destination: String, hasSelectedSchool: Bool) {
+        log("deep_link_opened", [
+            "destination": destination,
+            "has_selected_school": hasSelectedSchool
+        ])
+    }
+
+    private func log(_ name: String, _ parameters: [String: Any?] = [:]) {
+        Analytics.logEvent(name, parameters: parameters.compactMapValues { $0 })
+    }
+}

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Home/HomeView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Home/HomeView.swift
@@ -47,7 +47,7 @@ struct HomeView: View {
         .background(Color.bobmooGray4.ignoresSafeArea())
         .onChange(of: viewModel.currentDate) { oldValue, newValue in
             guard !Calendar.current.isDate(newValue, inSameDayAs: oldValue) else { return }
-            viewModel.dateDidChange()
+            viewModel.dateDidChange(from: oldValue, to: newValue)
         }
         .task(id: viewModel.currentDate) {
             await viewModel.preloadAroundCurrentDate()

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Home/HomeViewModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Home/HomeViewModel.swift
@@ -14,6 +14,7 @@ import Observation
 final class HomeViewModel {
     private let service: HomeMenuService
     private let settings: AppSettings
+    private let analytics = BobmooAnalytics.shared
 
     enum MealSection: CaseIterable, Hashable {
         case breakfast
@@ -37,8 +38,14 @@ final class HomeViewModel {
 
         let offset = newTab - 1
         let base = Calendar.current.startOfDay(for: currentDate)
+        let updatedDate = Calendar.current.date(byAdding: .day, value: offset, to: base)!
+        analytics.logDateSwiped(
+            direction: offset > 0 ? "next" : "previous",
+            fromDate: base,
+            toDate: updatedDate
+        )
         selectedTab = 1
-        currentDate = Calendar.current.date(byAdding: .day, value: offset, to: base)!
+        currentDate = updatedDate
     }
 
     // MARK: - Data
@@ -102,6 +109,10 @@ final class HomeViewModel {
     }
 
     func loadIfNeeded(date: Date) async {
+        await loadIfNeeded(date: date, source: "load_if_needed")
+    }
+
+    func loadIfNeeded(date: Date, source: String) async {
         let key = dateKey(date)
         guard menuCache[key] == nil, !loadingDates.contains(key) else { return }
 
@@ -113,27 +124,57 @@ final class HomeViewModel {
             withAnimation(.easeInOut(duration: 0.25)) {
                 menuCache[key] = result
             }
+            analytics.logMenuLoadSucceeded(
+                date: date,
+                schoolName: settings.selectedSchool,
+                cafeteriaCount: cafeterias(for: date).count,
+                source: source
+            )
         } catch {
             let school = settings.selectedSchool ?? ""
             if !school.isEmpty {
                 errorMessage = error.localizedDescription
+                analytics.logMenuLoadFailed(
+                    date: date,
+                    schoolName: school,
+                    source: source,
+                    errorMessage: error.localizedDescription
+                )
             }
             print("[HomeViewModel] loadIfNeeded(\(key)) failed: \(error)")
         }
     }
 
     func reloadDate(_ date: Date) async {
+        await reloadDate(date, source: "pull_to_refresh")
+    }
+
+    func reloadDate(_ date: Date, source: String) async {
         let key = dateKey(date)
         loadingDates.insert(key)
         defer { loadingDates.remove(key) }
+
+        analytics.logMenuReload(date: date, source: source)
 
         do {
             let result = try await service.fetchDailyMenu(date: date, school: settings.selectedSchool ?? "")
             withAnimation(.easeInOut(duration: 0.25)) {
                 menuCache[key] = result
             }
+            analytics.logMenuLoadSucceeded(
+                date: date,
+                schoolName: settings.selectedSchool,
+                cafeteriaCount: cafeterias(for: date).count,
+                source: source
+            )
         } catch {
             errorMessage = error.localizedDescription
+            analytics.logMenuLoadFailed(
+                date: date,
+                schoolName: settings.selectedSchool,
+                source: source,
+                errorMessage: error.localizedDescription
+            )
             print("[HomeViewModel] reloadDate(\(key)) failed: \(error)")
         }
     }
@@ -160,7 +201,17 @@ final class HomeViewModel {
 
     // MARK: - Date Change
 
-    func dateDidChange() {
+    func dateDidChange(from oldValue: Date, to newValue: Date) {
+        if isCalendarPresented {
+            analytics.logCalendarDateSelected(previousDate: oldValue, selectedDate: newValue)
+        }
+
+        analytics.logMenuViewed(
+            date: newValue,
+            schoolName: settings.selectedSchool,
+            cafeteriaCount: cafeterias(for: newValue).count,
+            source: isCalendarPresented ? "calendar" : "date_change"
+        )
         isCalendarPresented = false
     }
 
@@ -168,9 +219,9 @@ final class HomeViewModel {
         let base = Calendar.current.startOfDay(for: currentDate)
         let prev = Calendar.current.date(byAdding: .day, value: -1, to: base)!
         let next = Calendar.current.date(byAdding: .day, value: 1, to: base)!
-        await loadIfNeeded(date: base)
-        await loadIfNeeded(date: prev)
-        await loadIfNeeded(date: next)
+        await loadIfNeeded(date: base, source: "current_date")
+        await loadIfNeeded(date: prev, source: "preload_previous")
+        await loadIfNeeded(date: next, source: "preload_next")
     }
     // MARK: - Meal ordering
 

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/RootView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/RootView.swift
@@ -11,11 +11,13 @@ struct RootView: View {
     }
 
     let settings: AppSettings
+    private let analytics = BobmooAnalytics.shared
     @State private var route: Route = .splash
     @State private var homeViewModel: HomeViewModel
     @State private var searchViewModel: SearchViewModel
     @State private var pendingUpdateURL: URL?
     @State private var showUpdateAlert = false
+    @State private var didLogInitialAnalytics = false
 
     init(settings: AppSettings) {
         self.settings = settings
@@ -50,6 +52,7 @@ struct RootView: View {
 
             if route == .onboarding {
                 OnboardingView {
+                    analytics.logOnboardingStarted(hasSelectedSchool: settings.selectedSchool != nil)
                     withAnimation(.easeInOut(duration: 0.35)) {
                         route = settings.selectedSchool != nil ? .home : .search
                     }
@@ -59,6 +62,7 @@ struct RootView: View {
 
             if route == .home {
                 HomeView(viewModel: homeViewModel, onSetting: {
+                    analytics.logSettingsOpened(source: "home", schoolName: settings.selectedSchool)
                     withAnimation(.easeInOut(duration: 0.35)) {
                         route = .setting
                     }
@@ -73,6 +77,7 @@ struct RootView: View {
                         route = .home
                     }
                 }, onSearchSchool: {
+                    analytics.logSchoolSettingTapped(currentSchoolName: settings.selectedSchool)
                     withAnimation(.easeInOut(duration: 0.35)) {
                         route = .search
                     }
@@ -81,21 +86,31 @@ struct RootView: View {
             }
         }
         .animation(.easeInOut(duration: 0.35), value: route)
+        .task {
+            guard !didLogInitialAnalytics else { return }
+            didLogInitialAnalytics = true
+            analytics.logAppOpen(hasSelectedSchool: settings.selectedSchool != nil)
+            trackRoute(route, entryPoint: "app_launch")
+        }
         .alert("업데이트 안내", isPresented: $showUpdateAlert) {
             Button("업데이트") {
+                analytics.logUpdatePromptAction("update")
                 if let pendingUpdateURL {
                     UIApplication.shared.open(pendingUpdateURL)
                 }
                 pendingUpdateURL = nil
             }
             Button("나중에", role: .cancel) {
+                analytics.logUpdatePromptAction("later")
                 pendingUpdateURL = nil
             }
         } message: {
             Text("새로운 버전이 출시되었습니다.\n더 나은 경험을 위해 업데이트해 주세요.")
         }
         .onChange(of: route) { _, newRoute in
+            trackRoute(newRoute)
             if newRoute == .home, pendingUpdateURL != nil {
+                analytics.logUpdatePromptShown()
                 showUpdateAlert = true
             }
         }
@@ -103,12 +118,29 @@ struct RootView: View {
             guard url.scheme == "bobmoo" else { return }
 
             let destination = url.host ?? url.pathComponents.dropFirst().first ?? "home"
+            analytics.logDeepLinkOpened(destination: destination, hasSelectedSchool: settings.selectedSchool != nil)
             if destination == "home" {
                 homeViewModel.resetForSchoolChange()
                 withAnimation(.easeInOut(duration: 0.35)) {
                     route = settings.selectedSchool != nil ? .home : .search
                 }
             }
+        }
+    }
+
+    private func trackRoute(_ route: Route, entryPoint: String? = nil) {
+        switch route {
+        case .search:
+            analytics.logScreenView(.search, entryPoint: entryPoint)
+        case .splash:
+            analytics.logScreenView(.splash, entryPoint: entryPoint)
+        case .onboarding:
+            analytics.logScreenView(.onboarding, entryPoint: entryPoint)
+        case .home:
+            analytics.logScreenView(.home, entryPoint: entryPoint)
+            analytics.logHomeOpened(schoolName: settings.selectedSchool, date: homeViewModel.currentDate)
+        case .setting:
+            analytics.logScreenView(.setting, entryPoint: entryPoint)
         }
     }
 }

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SearchView: View {
     @Bindable var viewModel: SearchViewModel
     var didComplete: () -> Void
+    private let analytics = BobmooAnalytics.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -27,6 +28,10 @@ struct SearchView: View {
             Spacer()
 
             BobmooButton(label: "선택완료") {
+                analytics.logSchoolSelectionCompleted(
+                    selectedSchoolId: viewModel.selectedSchoolId,
+                    schoolName: viewModel.selectedSchoolName
+                )
                 didComplete()
             }
             .padding(.horizontal, 40)

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchViewModel.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Search/SearchViewModel.swift
@@ -14,6 +14,7 @@ import Observation
 final class SearchViewModel {
     private let service: SearchSchoolService
     private let settings: AppSettings
+    private let analytics = BobmooAnalytics.shared
 
     var schools: [School] = []
     var query: String = ""
@@ -22,6 +23,11 @@ final class SearchViewModel {
 
     var searchAmount: Int {
         schools.count
+    }
+
+    var selectedSchoolName: String? {
+        guard let selectedSchoolId else { return nil }
+        return allSchools.first { $0.schoolId == selectedSchoolId }?.queryName
     }
 
     private var allSchools: [School] = []
@@ -43,6 +49,7 @@ final class SearchViewModel {
             withAnimation(.easeInOut(duration: 0.25)) {
                 schools = allSchools
             }
+            analytics.logSearchResultsLoaded(count: allSchools.count)
         } catch {
             errorMessage = error.localizedDescription
             print("[SearchViewModel] loadAllSchools failed: \(error)")
@@ -58,6 +65,7 @@ final class SearchViewModel {
             withAnimation(.easeInOut(duration: 0.25)) {
                 schools = allSchools
             }
+            analytics.logSearch(queryLength: 0, resultCount: schools.count, isEmptyQuery: true)
             return
         }
 
@@ -69,11 +77,14 @@ final class SearchViewModel {
                 school.displayName.localizedCaseInsensitiveContains(trimmedQuery)
             }
         }
+
+        analytics.logSearch(queryLength: trimmedQuery.count, resultCount: schools.count, isEmptyQuery: false)
     }
 
     func selectSchool(_ school: School) {
         selectedSchoolId = school.schoolId
         settings.selectedSchool = school.queryName
         settings.selectedSchoolColor = school.schoolColor
+        analytics.logSchoolSelected(id: school.schoolId, name: school.queryName)
     }
 }

--- a/Bobmoo_iOS/Bobmoo_iOS/Presentation/Setting/SettingView.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Presentation/Setting/SettingView.swift
@@ -98,6 +98,7 @@ struct UnivSettingView: View {
 
 struct WidgetSettingView: View {
     @Environment(AppSettings.self) private var settings
+    private let analytics = BobmooAnalytics.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -140,6 +141,10 @@ struct WidgetSettingView: View {
         )
         .padding(.top, 20)
         .padding(.horizontal, 20)
+        .onChange(of: settings.selectedCafeteria) { oldValue, newValue in
+            guard oldValue != newValue else { return }
+            analytics.logWidgetCafeteriaChanged(previous: oldValue, current: newValue)
+        }
     }
 }
 

--- a/Bobmoo_iOS/Bobmoo_iOS/Resource/Components/BobmooCalendarButton.swift
+++ b/Bobmoo_iOS/Bobmoo_iOS/Resource/Components/BobmooCalendarButton.swift
@@ -10,6 +10,7 @@ import Observation
 
 struct BobmooCalendarButton: View {
     @Bindable var vm: HomeViewModel
+    private let analytics = BobmooAnalytics.shared
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -24,7 +25,10 @@ struct BobmooCalendarButton: View {
     }
      
     var body: some View {
-        Button(action: { vm.isCalendarPresented = true }) {
+        Button(action: {
+            analytics.logCalendarOpened(date: vm.currentDate)
+            vm.isCalendarPresented = true
+        }) {
             HStack(spacing: 6) {
                 BobmooText(formattedDate, style: .body_sb_12)
             }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #61
- Linear: https://linear.app/bobmoo/issue/BOB-92/feature-상세-firebase-analytics-이벤트-추가
- GitHub: https://github.com/Bobmoo-GamTwi/Bobmoo_iOS/issues/61
- [x] Linear/GitHub 이슈 상호 링크 확인

## 📄 작업 내용
- 검색, 학교 선택, 홈 진입, 메뉴 조회, 설정 진입 등 주요 퍼널에 Firebase Analytics 이벤트를 추가했습니다.
- `BobmooAnalytics` 공통 로깅 계층을 도입해 이벤트명과 파라미터 구성을 한곳에서 관리하도록 정리했습니다.
- 로컬 `GoogleService-Info.plist`와 파생 `.derivedData*`가 PR 범위에 포함되지 않도록 정리했습니다.

## 🧭 구현 의도 / 결정 이유
- 구현 의도: 주요 사용자 흐름을 Firebase DebugView와 이후 리포트에서 단계별로 추적할 수 있도록 이벤트를 세분화했습니다.
- 결정 이유: 화면별로 직접 `Analytics.logEvent`를 흩뿌리기보다 `BobmooAnalytics`로 감싸서 이벤트명, 날짜 포맷, 파라미터 키를 일관되게 유지하는 편이 확장과 유지보수에 유리합니다.
- 고려한 대안(선택): Firebase 기본 자동 수집 이벤트만 사용하는 방식도 가능했지만, 학교 선택/메뉴 조회처럼 도메인 맥락이 필요한 행동은 커스텀 이벤트가 필요하다고 판단했습니다.

## ✅ Testing
- 테스트 목적과 상황
  - Firebase Analytics 상세 이벤트 연동 이후 앱 빌드와 DebugView 수집 여부를 확인했습니다.

- 시나리오 진행에 필요한 값
  - Firebase가 연결된 로컬 개발 환경
  - 학교 선택이 가능한 앱 상태

- 시나리오 진행에 필요한 조건
  - 앱 실행 후 검색/학교 선택/홈 진입/날짜 이동/설정 진입 플로우를 수동으로 수행

- 시나리오 완료 시 보장하는 결과
  - `xcodebuild -project "Bobmoo_iOS/Bobmoo_iOS.xcodeproj" -scheme "Bobmoo_iOS" -destination 'generic/platform=iOS Simulator' build` 성공
  - Firebase DebugView에서 주요 이벤트 수집 확인

## 💻 주요 코드 설명
`Bobmoo_iOS/Bobmoo_iOS/Analytics/BobmooAnalytics.swift`
- 화면 진입, 학교 선택, 메뉴 조회, 업데이트 유도 등 커스텀 이벤트를 공통 메서드로 정의했습니다.
- 날짜 포맷과 nil 파라미터 제거를 공통 처리해 호출부는 이벤트 의미에만 집중하도록 구성했습니다.
```swift
private func log(_ name: String, _ parameters: [String: Any?] = [:]) {
    Analytics.logEvent(name, parameters: parameters.compactMapValues { $0 })
}
```